### PR TITLE
README: Update opening procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,10 +378,12 @@ prelininary bootloader into RAM, which we will use to flash the new image.
 The USB bootmode is implemented in the SoC bootrom and can thus not be
 corrupted by software running on the TAC.
 
-Unscrew the four screws holding the frontplate with the display in place.
-Pay close attention not to break the flat flex cable connecting the display
-to the mainboard. The display cable can be disconnected by opening the flap
-on the flat flex connector.
+Lay the device onto the top side (with the rubber feet facing up).
+Loosen the four lower screws just one or two threads.
+Unscrew the four upper screws.
+You can now lift the part with the rubber feet upwards.
+Make sure not to put too much strain on the flat flex cable connecting
+the lower and upper part.
 
 Connect the mainboard to your computer using an USB-C Cable.
 
@@ -397,7 +399,9 @@ This tells the device to boot into the serial update bootrom.
 ![LXA TAC Bootmode Pins BT0-BT2](readme-assets/bootmode-pins.jpg?raw=true "LXA TAC Bootmode Pins")
 
 Power on the device. It should show up in `lsusb` and `dmesg` on your host
-computer. Next you can upload the required pieces of software:
+computer.
+The device shows up as a `STMicroelectronics` `STM32  BOOTLOADER`.
+Next you can upload the required pieces of software:
 
 ### Flashing the software
 


### PR DESCRIPTION
With the Gen 2 devices the easiest way to access the bootmode pins is by removing the lower shell part containing the power board. So no need to disconnect the display anymore.